### PR TITLE
ACL Calculation added to scraper

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,6 +84,8 @@ type Config struct {
 	PolicyRecommendationRegistrar struct {
 		RequeueDelayMs int `yaml:"requeueDelayMs"`
 	} `yaml:"policyRecommendationRegistrar"`
+	MetricIngestionTime float64 `yaml:"metricIngestionTime"`
+	MetricProbeTime     float64 `yaml:"metricProbeTime"`
 }
 
 func main() {

--- a/pkg/metrics/scraper.go
+++ b/pkg/metrics/scraper.go
@@ -272,9 +272,6 @@ func (ps *PrometheusScraper) GetPodReadyLatencyByWorkload(namespace string,
 	}
 
 	podBootstrapTime := float64(matrix[0].Value)
-	if err != nil {
-		return 0.0, fmt.Errorf("")
-	}
 
 	return podBootstrapTime, nil
 }

--- a/pkg/metrics/suite_test.go
+++ b/pkg/metrics/suite_test.go
@@ -94,9 +94,11 @@ var _ = BeforeSuite(func() {
 		},
 		queryTimeout: 30 * time.Second}
 
+	metricIngestionTime := 15.0
+	metricProbeTime := 15.0
 	acl = &ACLComponents{scraper: scraper,
-		metricIngestionTime: MetricIngestionTime,
-		metricProbeTime:     MetricProbeTime}
+		metricIngestionTime: metricIngestionTime,
+		metricProbeTime:     metricProbeTime}
 
 	go func() {
 		metricsAddress = "localhost:9091"

--- a/pkg/trigger/monitor_test.go
+++ b/pkg/trigger/monitor_test.go
@@ -31,6 +31,11 @@ func (fs *FakeScraper) GetCPUUtilizationBreachDataPoints(namespace,
 	return []float64{1.3}, nil
 }
 
+func (fs *FakeScraper) GetPodReadyLatencyByWorkload(namespace,
+	workload string) (float64, error) {
+	return 0.0, nil
+}
+
 var _ = Describe("PolicyRecommendationMonitorManager and Monitor", func() {
 	var (
 		manager            *PolicyRecommendationMonitorManager


### PR DESCRIPTION
Implementation of ACL Calculation.
The PodBootstrap time fetching query is (Pod Ready Time - Pod Created Time). Have taken minimum of all the pods for a workload currently. 
Test is also written. 