### PR TITLE
made the delete scaledobject call a foreground cascading call

### DIFF
--- a/pkg/controller/hpaenforcement_controller.go
+++ b/pkg/controller/hpaenforcement_controller.go
@@ -629,7 +629,10 @@ func (r *HPAEnforcementController) deleteControllerManagedScaledObject(ctx conte
 		if scaledObject.Spec.MaxReplicaCount != nil {
 			maxPods = *scaledObject.Spec.MaxReplicaCount
 		}
-		err := r.Delete(ctx, &scaledObject)
+		deletePropagationPolicy := metav1.DeletePropagationForeground
+		err := r.Delete(ctx, &scaledObject, &client.DeleteOptions{
+			PropagationPolicy: &deletePropagationPolicy,
+		})
 		r.Recorder.Event(&policyreco, eventTypeNormal, "ScaledObjectDeleted", fmt.Sprintf("The ScaledObject '%s' has been deleted.", scaledObject.Name))
 		if err != nil {
 			logger.V(0).Error(err, "Error while deleting the scaledobject", "scaledobject", scaledObject)

--- a/pkg/controller/hpaenforcement_controller_test.go
+++ b/pkg/controller/hpaenforcement_controller_test.go
@@ -3657,6 +3657,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 		})
 
@@ -3830,6 +3833,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 
 		})
@@ -3996,6 +4002,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 		})
 
@@ -4183,6 +4192,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 		})
 
@@ -4391,6 +4403,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 		})
 
@@ -4565,6 +4580,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 
 		})
@@ -4732,6 +4750,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 		})
 
@@ -4920,6 +4941,9 @@ var _ = Describe("Test ScaledObject enforcer", func() {
 			}, timeout, interval).Should(Equal(initialMax))
 
 			scaledObject = &kedaapi.ScaledObject{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject)).Should(Succeed())
+			scaledObject.Finalizers = nil
+			Expect(k8sClient.Update(context.TODO(), scaledObject)).Should(Succeed())
 			Eventually(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: HPAEnforcerPolicyRecoNamespace, Name: HPAEnforcerPolicyRecoName}, scaledObject), timeout, interval).ShouldNot(Succeed())
 		})
 


### PR DESCRIPTION
- This is done so that the HPA deletion is ensure before resetting the spec.replicas of the workload